### PR TITLE
feat: 应用内自动更新系统(服务端代理 + 官网 + 自动发布)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: 发布 Release
+
+# 当推送形如 v2.5.4 的 tag 时自动触发；也支持手动触发
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: '要发布的 tag（如 v2.5.4），手动触发时使用'
+        required: true
+
+permissions:
+  contents: write   # 创建 Release、上传产物需要
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 配置 JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: 配置 Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: 赋予 gradlew 执行权限
+        run: chmod +x ./gradlew
+
+      - name: 还原签名密钥库
+        # 将 Base64 编码的 keystore secret 还原为文件
+        # 生成方式： base64 -w0 navi.jks  （或 Windows: certutil -encode）
+        env:
+          KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "$KEYSTORE_BASE64" ]; then
+            echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/navi-release.jks"
+            echo "KEYSTORE_PATH=$RUNNER_TEMP/navi-release.jks" >> "$GITHUB_ENV"
+          else
+            echo "未配置 SIGNING_KEYSTORE_BASE64，将使用仓库内 navi.jks（需配套密码 secret）"
+            echo "KEYSTORE_PATH=$GITHUB_WORKSPACE/navi.jks" >> "$GITHUB_ENV"
+          fi
+
+      - name: 构建签名 Release APK
+        env:
+          NAVI_STORE_FILE: ${{ env.KEYSTORE_PATH }}
+          NAVI_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          NAVI_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          NAVI_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew :app:assembleRelease --no-daemon
+
+      - name: 定位 APK
+        id: apk
+        run: |
+          APK=$(find app/build/outputs/apk/release -name "*.apk" | head -n1)
+          if [ -z "$APK" ]; then
+            echo "未找到 APK 产物" >&2
+            exit 1
+          fi
+          echo "path=$APK" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$APK")" >> "$GITHUB_OUTPUT"
+          echo "找到 APK: $APK"
+
+      - name: 解析版本号
+        id: ver
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [ -z "$TAG" ] || [ "$TAG" = "main" ] || [ "$TAG" = "master" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: 创建 GitHub Release 并上传 APK
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: Navi-Link ${{ steps.ver.outputs.tag }}
+          generate_release_notes: true   # 自动根据提交生成更新日志
+          draft: false
+          prerelease: false
+          files: ${{ steps.apk.outputs.path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/UPDATE_SYSTEM.md
+++ b/UPDATE_SYSTEM.md
@@ -1,0 +1,112 @@
+# 自动更新系统说明
+
+本仓库新增了一套完整的「自动更新」能力，由三部分组成：
+
+```
+┌─────────────────┐   推送 v* tag    ┌──────────────────────┐
+│  开发者 git tag  │ ───────────────> │ GitHub Action 自动构建 │
+└─────────────────┘                  │  签名 APK + 发布 Release │
+                                     └──────────┬───────────┘
+                                                │ Release + APK
+                                                ▼
+                                  ┌──────────────────────────────┐
+                                  │   树莓派服务（Node）            │
+                                  │   从 GitHub 拉取并缓存版本/APK   │
+                                  │   /api/latest  ·  /download/*  │
+                                  └───────┬───────────────┬────────┘
+                                          │               │
+                       官网下载页 (浏览器)  ▼               ▼  App 内更新检查
+                          ┌────────────────────┐   ┌──────────────────────────┐
+                          │ 苹果液态玻璃风官网    │   │ 请求服务 /api/latest 比对   │
+                          │ 下载走 /download/*    │   │ 有新版本则弹窗，下载走服务   │
+                          └────────────────────┘   └──────────────────────────┘
+```
+
+> **关键设计**：App **不直连 GitHub**（国内网络不稳定），而是请求自有服务获取版本信息，
+> 安装包也由服务从 GitHub 缓存后提供。服务地址在 App 中仅为**编译期常量**
+> （`BuildConfig.UPDATE_BASE_URL`），**不在任何界面显示**。
+
+---
+
+## 一、官网 + Release API（树莓派）
+
+代码位于 [`server/`](server/)。零依赖 Node.js 服务：
+
+- `GET /` —— 苹果液态玻璃风官网首页，动态展示最新版本与下载按钮
+- `GET /api/latest` —— 返回 GitHub 最新 release（带缓存）
+- `POST /api/sync` —— 手动强制刷新缓存
+- `GET /download/<文件名>` —— APK 下载代理：本地有缓存直接发，否则从 GitHub 回源并落盘
+- `GET /api/health` —— 健康检查
+
+本地启动：
+
+```bash
+cd server
+node server.js          # 打开 http://127.0.0.1:3000
+# 若本机网络使用企业自签 CA，导致 Node 无法校验 GitHub 证书：
+node --use-system-ca server.js
+```
+
+部署详见 [`server/README.md`](server/README.md)（含 systemd 与反向代理配置）。
+将 `navi-link.zuoqirun.top` 反代到该服务即可。
+
+## 二、App 内更新提示
+
+| 文件 | 作用 |
+|------|------|
+| `app/.../UpdateChecker.java` | 请求自有服务 `/api/latest`，比对版本（语义化数字比较），后台线程执行 |
+| `app/.../UpdateDialog.java` | 渲染深色风格更新弹窗，处理下载跳转 |
+| `app/.../res/layout/dialog_update.xml` | 弹窗布局 |
+| `MainActivity` | 启动时静默检查；设置页底部「检查更新」入口可手动检查 |
+
+- **静默检查**：App 启动时自动检查，仅在有新版本时弹窗，不打扰用户。
+- **手动检查**：设置页底部「检查更新」卡片，点击后即使已是最新也会 Toast 提示。
+- 服务地址通过 `BuildConfig.UPDATE_BASE_URL` 配置（默认 `https://navi-link.zuoqirun.top`），
+  在 `app/build.gradle` 中修改，或用 gradle 属性 / 环境变量 `NAVI_UPDATE_BASE_URL` 覆盖。
+  该地址**不在任何界面显示**。
+
+## 三、GitHub Action 自动发布
+
+工作流：[`.github/workflows/release.yml`](.github/workflows/release.yml)
+
+**触发方式**：推送 `v` 开头的 tag，例如：
+
+```bash
+git tag v2.5.4
+git push origin v2.5.4
+```
+
+流程：检出 → JDK 17 → 构建**签名** Release APK → 创建 GitHub Release（自动生成更新日志）→ 上传 APK。
+
+### 需要配置的仓库 Secrets
+
+在 GitHub 仓库 `Settings → Secrets and variables → Actions` 添加：
+
+| Secret | 说明 |
+|--------|------|
+| `SIGNING_STORE_PASSWORD` | 密钥库（navi.jks）密码 |
+| `SIGNING_KEY_ALIAS` | 密钥别名 |
+| `SIGNING_KEY_PASSWORD` | 密钥密码 |
+| `SIGNING_KEYSTORE_BASE64` | （可选）密钥库的 Base64。不配置则使用仓库内的 `navi.jks` |
+
+> 仓库已包含 `navi.jks`，若沿用它，只需配置上面三个密码类 secret，
+> 不必配置 `SIGNING_KEYSTORE_BASE64`。
+>
+> 若想用独立密钥库（推荐，避免私钥进仓库），用以下命令生成 Base64 后填入
+> `SIGNING_KEYSTORE_BASE64`：
+> ```bash
+> base64 -w0 your-release.jks        # Linux/Mac
+> ```
+
+### 版本号
+
+发布前请同步修改 `app/build.gradle` 中的 `versionCode` 与 `versionName`，
+使其与 tag 对应（App 比对的是 `versionName`）。
+
+---
+
+## 本地构建说明
+
+- 项目路径含中文，已在 `gradle.properties` 加 `android.overridePathCheck=true`。
+- `local.properties`（SDK 路径）与签名密码均不入库；本地无签名配置时
+  Release 构建会自动回退为未签名，不会失败。

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,46 @@ android {
         versionName "2.5.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // 更新服务地址。App 通过该服务（部署于自有服务器）获取版本信息与下载安装包，
+        // 由服务器缓存 GitHub 数据，客户端无需直连 GitHub。
+        // 仅作编译期常量，不在界面显示。可被 gradle 属性/环境变量覆盖。
+        def updateBaseUrl = (project.findProperty('NAVI_UPDATE_BASE_URL')
+                ?: System.getenv('NAVI_UPDATE_BASE_URL')) ?: 'https://navi-link.zuoqirun.top'
+        buildConfigField "String", "UPDATE_BASE_URL", "\"${updateBaseUrl}\""
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    // 签名配置：优先读取环境变量 / Gradle 属性（供 CI 使用），
+    // 本地未配置时回退到仓库内的 navi.jks（仅用于本地调试构建）。
+    signingConfigs {
+        release {
+            def storeFilePath = (project.findProperty('NAVI_STORE_FILE') ?: System.getenv('NAVI_STORE_FILE')) ?: '../navi.jks'
+            def storePass = (project.findProperty('NAVI_STORE_PASSWORD') ?: System.getenv('NAVI_STORE_PASSWORD')) ?: ''
+            def keyAliasProp = (project.findProperty('NAVI_KEY_ALIAS') ?: System.getenv('NAVI_KEY_ALIAS')) ?: ''
+            def keyPass = (project.findProperty('NAVI_KEY_PASSWORD') ?: System.getenv('NAVI_KEY_PASSWORD')) ?: ''
+            def f = file(storeFilePath)
+            if (f.exists() && !storePass.isEmpty() && !keyAliasProp.isEmpty()) {
+                storeFile f
+                storePassword storePass
+                keyAlias keyAliasProp
+                keyPassword keyPass
+            }
+        }
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            // 仅当签名信息齐全时启用签名，否则走默认（debug 或未签名），避免本地构建失败
+            def rel = signingConfigs.release
+            if (rel.storeFile != null && rel.storePassword != null && rel.keyAlias != null) {
+                signingConfig rel
+            }
         }
     }
     compileOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
@@ -72,6 +75,22 @@
                 <action android:name="com.nwd.action.ACTION_MCU_STATE_CHANGE" />
             </intent-filter>
         </receiver>
+
+        <!-- 用于向安装器（系统安装器 / InstallerX）传递 APK 文件的 content:// URI -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
+        <!-- 安装会话结果回调接收器（PackageInstaller） -->
+        <receiver
+            android:name=".InstallResultReceiver"
+            android:exported="false" />
 
     </application>
 

--- a/app/src/main/java/com/navi/link/ApkDownloader.java
+++ b/app/src/main/java/com/navi/link/ApkDownloader.java
@@ -1,0 +1,152 @@
+package com.navi.link;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * APK 下载器。将更新服务提供的安装包下载到应用缓存目录，带进度回调。
+ *
+ * <p>下载目标目录为 {@code context.getCacheDir()/apk/}，与 {@code file_paths.xml}
+ * 中的 {@code cache-path name="apk_cache" path="apk/"} 对应，供 FileProvider 暴露。</p>
+ */
+public final class ApkDownloader {
+
+    private static final String TAG = "ApkDownloader";
+    private static final int CONNECT_TIMEOUT_MS = 15000;
+    private static final int READ_TIMEOUT_MS = 30000;
+    private static final int MAX_REDIRECTS = 5;
+
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+    private static final Handler MAIN = new Handler(Looper.getMainLooper());
+
+    private ApkDownloader() {}
+
+    /** 下载进度回调，全部在主线程触发。 */
+    public interface Callback {
+        /** 进度更新。total 为 -1 表示未知总大小（无 Content-Length）。 */
+        void onProgress(long downloaded, long total);
+
+        /** 下载完成，apkFile 为本地文件。 */
+        void onComplete(File apkFile);
+
+        /** 下载失败。 */
+        void onError(String message);
+    }
+
+    /**
+     * 异步下载 APK。
+     *
+     * @param cacheDir   通常传 context.getCacheDir()
+     * @param url        下载地址（更新服务返回的绝对地址）
+     * @param fileName   保存的文件名
+     * @param callback   进度/结果回调（主线程）
+     */
+    public static void download(File cacheDir, String url, String fileName, Callback callback) {
+        EXECUTOR.execute(() -> {
+            HttpURLConnection conn = null;
+            try {
+                File dir = new File(cacheDir, "apk");
+                if (!dir.exists() && !dir.mkdirs()) {
+                    postError(callback, "无法创建下载目录");
+                    return;
+                }
+                // 清理同名旧文件，避免半成品复用
+                File out = new File(dir, sanitize(fileName));
+                if (out.exists() && !out.delete()) {
+                    Log.w(TAG, "无法删除旧文件: " + out);
+                }
+
+                conn = openWithRedirects(url);
+                int code = conn.getResponseCode();
+                if (code < 200 || code >= 300) {
+                    postError(callback, "下载失败 HTTP " + code);
+                    return;
+                }
+
+                final long total = conn.getContentLengthLong();
+                long downloaded = 0;
+                long lastPosted = 0;
+
+                try (InputStream in = conn.getInputStream();
+                     FileOutputStream fos = new FileOutputStream(out)) {
+                    byte[] buf = new byte[8192];
+                    int n;
+                    while ((n = in.read(buf)) != -1) {
+                        fos.write(buf, 0, n);
+                        downloaded += n;
+                        // 节流：每累计 ~64KB 或读到末尾回调一次，避免主线程过载
+                        if (downloaded - lastPosted >= 65536) {
+                            lastPosted = downloaded;
+                            final long d = downloaded;
+                            MAIN.post(() -> callback.onProgress(d, total));
+                        }
+                    }
+                    fos.flush();
+                }
+
+                final long finalSize = downloaded;
+                if (finalSize <= 0) {
+                    postError(callback, "下载内容为空");
+                    return;
+                }
+                MAIN.post(() -> {
+                    callback.onProgress(finalSize, total > 0 ? total : finalSize);
+                    callback.onComplete(out);
+                });
+            } catch (Exception e) {
+                Log.w(TAG, "下载 APK 失败", e);
+                postError(callback, e.getMessage() != null ? e.getMessage() : "网络错误");
+            } finally {
+                if (conn != null) conn.disconnect();
+            }
+        });
+    }
+
+    /** 打开连接并手动跟随重定向（HttpURLConnection 不会在 http↔https 间自动跳转）。 */
+    private static HttpURLConnection openWithRedirects(String urlStr) throws Exception {
+        String current = urlStr;
+        for (int i = 0; i <= MAX_REDIRECTS; i++) {
+            URL url = new URL(current);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setInstanceFollowRedirects(false);
+            conn.setRequestProperty("User-Agent", "Navi-Link-Android");
+            conn.setRequestProperty("Accept", "application/vnd.android.package-archive, */*");
+
+            int code = conn.getResponseCode();
+            if (code >= 300 && code < 400) {
+                String loc = conn.getHeaderField("Location");
+                conn.disconnect();
+                if (TextUtils.isEmpty(loc)) throw new Exception("重定向缺少 Location");
+                // 处理相对重定向
+                current = new URL(new URL(current), loc).toString();
+                continue;
+            }
+            return conn;
+        }
+        throw new Exception("重定向次数过多");
+    }
+
+    private static void postError(Callback cb, String msg) {
+        MAIN.post(() -> cb.onError(msg));
+    }
+
+    /** 文件名兜底清洗，避免空名或非法字符。 */
+    private static String sanitize(String name) {
+        if (TextUtils.isEmpty(name)) return "update.apk";
+        String s = name.replaceAll("[\\\\/:*?\"<>|]", "_");
+        if (!s.toLowerCase().endsWith(".apk")) s = s + ".apk";
+        return s;
+    }
+}

--- a/app/src/main/java/com/navi/link/ApkInstaller.java
+++ b/app/src/main/java/com/navi/link/ApkInstaller.java
@@ -1,0 +1,181 @@
+package com.navi.link;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.core.content.FileProvider;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * APK 安装器 —— 三级安装链。
+ *
+ * <p>按以下顺序尝试安装，前一种失败则回退到后一种：</p>
+ * <ol>
+ *   <li>系统 {@link PackageInstaller}：应用内创建安装会话（会弹系统确认框）</li>
+ *   <li>InstallerX（{@code com.rosan.installer.x}）：显式调用其安装界面</li>
+ *   <li>系统安装器：标准 {@code ACTION_VIEW}，由系统默认安装器处理</li>
+ * </ol>
+ */
+public final class ApkInstaller {
+
+    private static final String TAG = "ApkInstaller";
+
+    /** InstallerX 包名。 */
+    private static final String INSTALLERX_PKG = "com.rosan.installer.x";
+
+    private static final String APK_MIME = "application/vnd.android.package-archive";
+
+    private ApkInstaller() {}
+
+    /**
+     * 安装 APK。依次尝试三级安装链。
+     *
+     * @param context 建议传 Activity context
+     * @param apkFile 已下载到本地的 APK 文件
+     */
+    public static void install(Context context, File apkFile) {
+        if (apkFile == null || !apkFile.exists() || apkFile.length() == 0) {
+            Toast.makeText(context, "安装包不存在或为空", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // 1) 系统 PackageInstaller
+        if (tryPackageInstaller(context, apkFile)) {
+            Log.i(TAG, "使用 PackageInstaller 安装");
+            return;
+        }
+
+        // 2) InstallerX
+        if (tryInstallerX(context, apkFile)) {
+            Log.i(TAG, "回退到 InstallerX 安装");
+            return;
+        }
+
+        // 3) 系统安装器
+        if (trySystemInstaller(context, apkFile)) {
+            Log.i(TAG, "回退到系统安装器");
+            return;
+        }
+
+        Toast.makeText(context, "未找到可用的安装方式", Toast.LENGTH_LONG).show();
+    }
+
+    // ── 1) PackageInstaller ─────────────────────────────────────
+    private static boolean tryPackageInstaller(Context context, File apkFile) {
+        PackageInstaller.Session session = null;
+        try {
+            PackageInstaller installer = context.getPackageManager().getPackageInstaller();
+            PackageInstaller.SessionParams params = new PackageInstaller.SessionParams(
+                    PackageInstaller.SessionParams.MODE_FULL_INSTALL);
+
+            int sessionId = installer.createSession(params);
+            session = installer.openSession(sessionId);
+
+            // 写入 APK 数据
+            try (InputStream in = new FileInputStream(apkFile);
+                 OutputStream out = session.openWrite("base.apk", 0, apkFile.length())) {
+                byte[] buf = new byte[16384];
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+                session.fsync(out);
+            }
+
+            // 结果回调 PendingIntent → InstallResultReceiver
+            Intent intent = new Intent(context, InstallResultReceiver.class);
+            int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                flags |= PendingIntent.FLAG_MUTABLE;
+            }
+            PendingIntent pi = PendingIntent.getBroadcast(
+                    context, sessionId, intent, flags);
+
+            session.commit(pi.getIntentSender());
+            // commit 成功（系统会随后通过 receiver 弹确认框）
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "PackageInstaller 安装失败，准备回退", e);
+            if (session != null) {
+                try { session.abandon(); } catch (Exception ignore) {}
+            }
+            return false;
+        } finally {
+            if (session != null) session.close();
+        }
+    }
+
+    // ── 2) InstallerX ───────────────────────────────────────────
+    private static boolean tryInstallerX(Context context, File apkFile) {
+        if (!isPackageInstalled(context, INSTALLERX_PKG)) {
+            Log.i(TAG, "未安装 InstallerX，跳过");
+            return false;
+        }
+        try {
+            Uri uri = uriFor(context, apkFile);
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setDataAndType(uri, APK_MIME);
+            intent.setPackage(INSTALLERX_PKG);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            // 确认 InstallerX 能处理该 intent
+            if (intent.resolveActivity(context.getPackageManager()) == null) {
+                Log.i(TAG, "InstallerX 无法处理安装 intent");
+                return false;
+            }
+            context.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "InstallerX 安装失败，准备回退", e);
+            return false;
+        }
+    }
+
+    // ── 3) 系统安装器 ───────────────────────────────────────────
+    private static boolean trySystemInstaller(Context context, File apkFile) {
+        try {
+            Uri uri = uriFor(context, apkFile);
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setDataAndType(uri, APK_MIME);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            if (intent.resolveActivity(context.getPackageManager()) == null) {
+                Log.w(TAG, "系统无可处理 APK 安装的应用");
+                return false;
+            }
+            context.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "系统安装器调用失败", e);
+            return false;
+        }
+    }
+
+    // ── 工具 ────────────────────────────────────────────────────
+    private static Uri uriFor(Context context, File apkFile) {
+        String authority = context.getPackageName() + ".fileprovider";
+        return FileProvider.getUriForFile(context, authority, apkFile);
+    }
+
+    private static boolean isPackageInstalled(Context context, String pkg) {
+        try {
+            context.getPackageManager().getPackageInfo(pkg, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/navi/link/InstallResultReceiver.java
+++ b/app/src/main/java/com/navi/link/InstallResultReceiver.java
@@ -1,0 +1,59 @@
+package com.navi.link;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInstaller;
+import android.os.Build;
+import android.widget.Toast;
+
+/**
+ * PackageInstaller 会话提交后的结果回调接收器。
+ *
+ * <p>系统需要用户确认安装时会返回 {@link PackageInstaller#STATUS_PENDING_USER_ACTION}，
+ * 此时携带一个确认 Intent，需要由本接收器拉起。</p>
+ */
+public class InstallResultReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS,
+                PackageInstaller.STATUS_FAILURE);
+
+        switch (status) {
+            case PackageInstaller.STATUS_PENDING_USER_ACTION:
+                // 需要用户确认：拉起系统安装确认界面
+                Intent confirm = getConfirmIntent(intent);
+                if (confirm != null) {
+                    confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    try {
+                        context.startActivity(confirm);
+                    } catch (Exception e) {
+                        toast(context, "无法打开安装确认界面");
+                    }
+                }
+                break;
+
+            case PackageInstaller.STATUS_SUCCESS:
+                toast(context, "安装成功");
+                break;
+
+            default:
+                String msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE);
+                toast(context, "安装未完成" + (msg != null ? "：" + msg : ""));
+                break;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Intent getConfirmIntent(Intent intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent.class);
+        }
+        return intent.getParcelableExtra(Intent.EXTRA_INTENT);
+    }
+
+    private static void toast(Context context, String msg) {
+        Toast.makeText(context.getApplicationContext(), msg, Toast.LENGTH_SHORT).show();
+    }
+}

--- a/app/src/main/java/com/navi/link/MainActivity.java
+++ b/app/src/main/java/com/navi/link/MainActivity.java
@@ -245,9 +245,64 @@ public class MainActivity extends AppCompatActivity {
         loadPreferences();
         setupListeners();
         updateStatusText();
+        setupUpdateEntry();
         if (savedInstanceState == null) {
             checkPermissionAndStart();
+            // 启动时静默检查更新（仅在有新版本时弹窗）
+            UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME, false, updateCallback(false));
         }
+    }
+
+    // ── 应用内更新 ──────────────────────────────────────────────
+    private TextView tvVersionStatus;
+
+    /** 绑定"检查更新"入口卡片，展示当前版本，点击手动检查。 */
+    private void setupUpdateEntry() {
+        tvVersionStatus = findViewById(R.id.tv_version_status);
+        if (tvVersionStatus != null) {
+            tvVersionStatus.setText("当前版本 v" + BuildConfig.VERSION_NAME);
+        }
+        View card = findViewById(R.id.card_check_update);
+        if (card != null) {
+            card.setOnClickListener(v -> {
+                if (tvVersionStatus != null) tvVersionStatus.setText("正在检查更新…");
+                UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME, true, updateCallback(true));
+            });
+        }
+    }
+
+    /** 构造更新检查回调。manual=true 时，"已最新/失败"也会给出提示。 */
+    private UpdateChecker.Callback updateCallback(boolean manual) {
+        return new UpdateChecker.Callback() {
+            @Override
+            public void onUpdateAvailable(UpdateChecker.UpdateInfo info) {
+                if (isFinishing() || isDestroyed()) return;
+                if (tvVersionStatus != null) {
+                    tvVersionStatus.setText("发现新版本 v" + info.versionName);
+                }
+                UpdateDialog.show(MainActivity.this, BuildConfig.VERSION_NAME, info);
+            }
+
+            @Override
+            public void onNoUpdate(boolean manual) {
+                if (tvVersionStatus != null) {
+                    tvVersionStatus.setText("当前版本 v" + BuildConfig.VERSION_NAME + "（已是最新）");
+                }
+                if (manual) {
+                    Toast.makeText(MainActivity.this, "已是最新版本", Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onError(String message, boolean manual) {
+                if (tvVersionStatus != null) {
+                    tvVersionStatus.setText("当前版本 v" + BuildConfig.VERSION_NAME);
+                }
+                if (manual) {
+                    Toast.makeText(MainActivity.this, "检查更新失败：" + message, Toast.LENGTH_SHORT).show();
+                }
+            }
+        };
     }
 
     private void initViews() {

--- a/app/src/main/java/com/navi/link/UpdateChecker.java
+++ b/app/src/main/java/com/navi/link/UpdateChecker.java
@@ -1,0 +1,263 @@
+package com.navi.link;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * 应用内更新检查器。
+ *
+ * <p>通过自有更新服务（{@link BuildConfig#UPDATE_BASE_URL}）获取最新版本信息，
+ * 与当前 versionName 比对，判断是否有新版本可用。版本数据与安装包均由服务器
+ * 缓存自 GitHub，客户端无需直连 GitHub（国内网络更稳定）。</p>
+ *
+ * <p>不依赖任何第三方库。服务地址仅为编译期常量，不在界面中展示。</p>
+ *
+ * <p>用法：</p>
+ * <pre>
+ *   UpdateChecker.checkForUpdate(BuildConfig.VERSION_NAME, false, callback);
+ * </pre>
+ */
+public final class UpdateChecker {
+
+    private static final String TAG = "UpdateChecker";
+
+    /** 更新服务基地址（自有服务器，不在 UI 显示）。 */
+    private static final String BASE_URL = trimTrailingSlash(BuildConfig.UPDATE_BASE_URL);
+
+    /** 最新版本信息接口。 */
+    private static final String API_LATEST = BASE_URL + "/api/latest";
+
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+    private static final int READ_TIMEOUT_MS = 10000;
+
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+    private static final Handler MAIN = new Handler(Looper.getMainLooper());
+
+    private UpdateChecker() {}
+
+    /** 检查结果回调，全部在主线程触发。 */
+    public interface Callback {
+        /** 发现新版本。 */
+        void onUpdateAvailable(UpdateInfo info);
+
+        /** 已是最新版本。manual 为 true 时（用户手动点击）才需要提示。 */
+        void onNoUpdate(boolean manual);
+
+        /** 检查失败（网络异常、解析失败等）。manual 为 true 时才需要提示。 */
+        void onError(String message, boolean manual);
+    }
+
+    /** 新版本信息。 */
+    public static final class UpdateInfo {
+        public final String versionName;   // 去掉前缀 v 的版本号，如 2.5.4
+        public final String tagName;       // 原始 tag，如 v2.5.4
+        public final String releaseName;   // release 标题
+        public final String notes;         // 更新说明（markdown 原文）
+        public final String apkUrl;        // APK 直接下载地址（可能为空）
+        public final String htmlUrl;       // release 页面地址（兜底）
+        public final long apkSize;         // APK 字节数（可能为 0）
+
+        UpdateInfo(String versionName, String tagName, String releaseName,
+                   String notes, String apkUrl, String htmlUrl, long apkSize) {
+            this.versionName = versionName;
+            this.tagName = tagName;
+            this.releaseName = releaseName;
+            this.notes = notes;
+            this.apkUrl = apkUrl;
+            this.htmlUrl = htmlUrl;
+            this.apkSize = apkSize;
+        }
+
+        /** 下载地址：优先 APK 直链，否则回退到 release 页面。 */
+        public String bestDownloadUrl() {
+            return !TextUtils.isEmpty(apkUrl) ? apkUrl : htmlUrl;
+        }
+    }
+
+    /**
+     * 异步检查更新。
+     *
+     * @param currentVersionName 当前应用 versionName（通常取自 BuildConfig.VERSION_NAME）
+     * @param manual             是否用户手动触发（决定"已最新/失败"是否提示）
+     * @param callback           结果回调（主线程）
+     */
+    public static void checkForUpdate(String currentVersionName, boolean manual, Callback callback) {
+        EXECUTOR.execute(() -> {
+            try {
+                String json = httpGet(API_LATEST);
+                UpdateInfo info = parseRelease(json);
+                if (info == null) {
+                    post(() -> callback.onError("解析发布信息失败", manual));
+                    return;
+                }
+                if (isNewer(info.versionName, currentVersionName)) {
+                    post(() -> callback.onUpdateAvailable(info));
+                } else {
+                    post(() -> callback.onNoUpdate(manual));
+                }
+            } catch (NotFoundException e) {
+                // 仓库尚无 release
+                post(() -> callback.onNoUpdate(manual));
+            } catch (Exception e) {
+                Log.w(TAG, "检查更新失败", e);
+                final String msg = e.getMessage() != null ? e.getMessage() : "网络错误";
+                post(() -> callback.onError(msg, manual));
+            }
+        });
+    }
+
+    // ── 网络 ────────────────────────────────────────────────────
+    private static String httpGet(String urlStr) throws Exception {
+        HttpURLConnection conn = null;
+        try {
+            URL url = new URL(urlStr);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestProperty("Accept", "application/json");
+            conn.setRequestProperty("User-Agent", "Navi-Link-Android");
+
+            int code = conn.getResponseCode();
+            if (code == 404) {
+                throw new NotFoundException();
+            }
+            if (code < 200 || code >= 300) {
+                throw new Exception("更新服务 HTTP " + code);
+            }
+            try (InputStream is = conn.getInputStream()) {
+                return readAll(is);
+            }
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    private static String readAll(InputStream is) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                sb.append(line).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    // ── 解析 ────────────────────────────────────────────────────
+    // 解析更新服务返回的 JSON（字段：version / name / body / html_url(htmlUrl) /
+    // apk:{name,size,downloadUrl} ）。downloadUrl 可能是相对路径，需补全为绝对地址。
+    private static UpdateInfo parseRelease(String json) {
+        try {
+            JSONObject o = new JSONObject(json);
+
+            // 服务端若返回 error 字段，视为失败
+            if (o.has("error")) {
+                Log.w(TAG, "更新服务返回错误: " + o.optString("message", o.optString("error")));
+                return null;
+            }
+
+            String tag = o.optString("version", o.optString("name", ""));
+            if (TextUtils.isEmpty(tag)) return null;
+            String version = stripV(tag);
+            String name = o.optString("name", tag);
+            String notes = o.optString("body", "");
+            String htmlUrl = o.optString("htmlUrl", o.optString("html_url", ""));
+
+            String apkUrl = "";
+            long apkSize = 0;
+            JSONObject apk = o.optJSONObject("apk");
+            if (apk != null) {
+                apkUrl = apk.optString("downloadUrl", "");
+                apkSize = apk.optLong("size", 0);
+            }
+            // 把相对下载地址补全为绝对地址（基于更新服务 base url）
+            apkUrl = absolutize(apkUrl);
+            htmlUrl = absolutize(htmlUrl);
+
+            return new UpdateInfo(version, tag, name, notes, apkUrl, htmlUrl, apkSize);
+        } catch (Exception e) {
+            Log.w(TAG, "解析更新信息失败", e);
+            return null;
+        }
+    }
+
+    /** 把相对路径（/download/xxx）补全为基于更新服务的绝对 URL。 */
+    private static String absolutize(String url) {
+        if (TextUtils.isEmpty(url)) return "";
+        if (url.startsWith("http://") || url.startsWith("https://")) return url;
+        if (url.startsWith("/")) return BASE_URL + url;
+        return BASE_URL + "/" + url;
+    }
+
+    /** 去掉 BASE_URL 末尾斜杠。 */
+    private static String trimTrailingSlash(String s) {
+        if (s == null) return "";
+        while (s.endsWith("/")) s = s.substring(0, s.length() - 1);
+        return s;
+    }
+
+    // ── 版本比较 ─────────────────────────────────────────────────
+    /** 去掉版本号前缀的 v / V。 */
+    static String stripV(String v) {
+        if (v == null) return "";
+        v = v.trim();
+        if (v.startsWith("v") || v.startsWith("V")) v = v.substring(1);
+        return v.trim();
+    }
+
+    /**
+     * 判断 remote 是否比 local 新。语义化数字比较（点分），
+     * 非数字后缀（如 -beta）忽略其数值，仅按数字段比较；段数不足按 0 补齐。
+     */
+    static boolean isNewer(String remote, String local) {
+        int[] r = parseVersion(stripV(remote));
+        int[] l = parseVersion(stripV(local));
+        int n = Math.max(r.length, l.length);
+        for (int i = 0; i < n; i++) {
+            int rv = i < r.length ? r[i] : 0;
+            int lv = i < l.length ? l[i] : 0;
+            if (rv != lv) return rv > lv;
+        }
+        return false;
+    }
+
+    private static int[] parseVersion(String v) {
+        if (TextUtils.isEmpty(v)) return new int[]{0};
+        // 取首个连续的 "数字.数字..." 片段，丢弃后缀（如 2.5.4-rc1 → 2.5.4）
+        String core = v.split("[^0-9.]")[0];
+        if (TextUtils.isEmpty(core)) return new int[]{0};
+        String[] parts = core.split("\\.");
+        int[] out = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            try {
+                out[i] = parts[i].isEmpty() ? 0 : Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                out[i] = 0;
+            }
+        }
+        return out;
+    }
+
+    // ── 工具 ────────────────────────────────────────────────────
+    private static void post(Runnable r) {
+        MAIN.post(r);
+    }
+
+    /** GitHub 仓库无 release 时返回 404，用此专用异常区分。 */
+    private static final class NotFoundException extends Exception {}
+}

--- a/app/src/main/java/com/navi/link/UpdateDialog.java
+++ b/app/src/main/java/com/navi/link/UpdateDialog.java
@@ -1,0 +1,191 @@
+package com.navi.link;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.google.android.material.button.MaterialButton;
+
+import java.io.File;
+import java.util.Locale;
+
+/**
+ * 更新提示对话框。把 {@link UpdateChecker.UpdateInfo} 渲染成深色风格弹窗，
+ * 「立即更新」点击后在应用内下载 APK（显示进度），完成后走三级安装链
+ * （{@link ApkInstaller}）。
+ */
+public final class UpdateDialog {
+
+    private UpdateDialog() {}
+
+    /**
+     * 显示更新提示框。
+     *
+     * @param context     建议传入 Activity context
+     * @param currentVer  当前版本名（用于"旧 → 新"展示）
+     * @param info        新版本信息
+     */
+    public static void show(Context context, String currentVer, UpdateChecker.UpdateInfo info) {
+        View view = LayoutInflater.from(context).inflate(R.layout.dialog_update, null);
+
+        TextView tvVersion = view.findViewById(R.id.tv_update_version);
+        TextView tvSize = view.findViewById(R.id.tv_update_size);
+        TextView tvNotes = view.findViewById(R.id.tv_update_notes);
+        MaterialButton btnNow = view.findViewById(R.id.btn_update_now);
+        MaterialButton btnLater = view.findViewById(R.id.btn_update_later);
+
+        tvVersion.setText(String.format(Locale.getDefault(), "v%s  →  v%s",
+                UpdateChecker.stripV(currentVer), info.versionName));
+
+        if (info.apkSize > 0) {
+            tvSize.setVisibility(View.VISIBLE);
+            tvSize.setText("安装包大小 " + formatSize(info.apkSize));
+        }
+
+        tvNotes.setText(cleanNotes(info.notes));
+
+        AlertDialog dialog = new AlertDialog.Builder(context)
+                .setView(view)
+                .setCancelable(true)
+                .create();
+
+        // 去掉系统默认白色背景，露出自定义圆角背景
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+        }
+
+        btnNow.setOnClickListener(v ->
+                startDownloadAndInstall(context, info, dialog, btnNow, btnLater));
+        btnLater.setOnClickListener(v -> dialog.dismiss());
+
+        dialog.show();
+    }
+
+    /** 下载并安装。下载过程中按钮显示进度，期间禁止关闭。 */
+    private static void startDownloadAndInstall(Context context, UpdateChecker.UpdateInfo info,
+                                                AlertDialog dialog, MaterialButton btnNow,
+                                                MaterialButton btnLater) {
+        String url = info.bestDownloadUrl();
+        if (TextUtils.isEmpty(url)) {
+            Toast.makeText(context, "下载地址不可用", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // 进入下载态：禁用按钮、锁定对话框
+        btnNow.setEnabled(false);
+        btnLater.setEnabled(false);
+        dialog.setCancelable(false);
+        btnNow.setText("准备下载…");
+
+        String fileName = buildFileName(info);
+
+        ApkDownloader.download(context.getCacheDir(), url, fileName, new ApkDownloader.Callback() {
+            @Override
+            public void onProgress(long downloaded, long total) {
+                if (total > 0) {
+                    int pct = (int) (downloaded * 100 / total);
+                    btnNow.setText("下载中 " + pct + "%");
+                } else {
+                    btnNow.setText("下载中 " + formatSize(downloaded));
+                }
+            }
+
+            @Override
+            public void onComplete(File apkFile) {
+                btnNow.setText("准备安装…");
+                proceedInstall(context, apkFile, dialog, btnNow, btnLater);
+            }
+
+            @Override
+            public void onError(String message) {
+                Toast.makeText(context, "下载失败：" + message, Toast.LENGTH_LONG).show();
+                // 恢复，允许重试
+                btnNow.setEnabled(true);
+                btnLater.setEnabled(true);
+                dialog.setCancelable(true);
+                btnNow.setText("重试");
+            }
+        });
+    }
+
+    /** 检查未知来源安装权限，必要时引导开启；有权限则启动安装链。 */
+    private static void proceedInstall(Context context, File apkFile, AlertDialog dialog,
+                                       MaterialButton btnNow, MaterialButton btnLater) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && !context.getPackageManager().canRequestPackageInstalls()) {
+            // 无"安装未知应用"权限：引导用户去开启
+            Toast.makeText(context, "请允许安装未知来源应用后重试", Toast.LENGTH_LONG).show();
+            try {
+                Intent intent = new Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                        Uri.parse("package:" + context.getPackageName()));
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(intent);
+            } catch (Exception e) {
+                // 部分车机无该设置页，回退到安装链让系统自行处理
+                ApkInstaller.install(context, apkFile);
+                dialog.dismiss();
+                return;
+            }
+            // 已下载完成，恢复按钮让用户授权后点击安装
+            btnNow.setEnabled(true);
+            btnLater.setEnabled(true);
+            dialog.setCancelable(true);
+            btnNow.setText("安装");
+            btnNow.setOnClickListener(v -> {
+                ApkInstaller.install(context, apkFile);
+                dialog.dismiss();
+            });
+            return;
+        }
+
+        ApkInstaller.install(context, apkFile);
+        dialog.dismiss();
+    }
+
+    /** 构造保存文件名：优先 release 里的 APK 名，否则按版本生成。 */
+    private static String buildFileName(UpdateChecker.UpdateInfo info) {
+        String url = info.apkUrl;
+        if (!TextUtils.isEmpty(url)) {
+            int slash = url.lastIndexOf('/');
+            String name = slash >= 0 ? url.substring(slash + 1) : url;
+            // 去掉可能的 query
+            int q = name.indexOf('?');
+            if (q >= 0) name = name.substring(0, q);
+            try {
+                name = Uri.decode(name);
+            } catch (Exception ignore) {}
+            if (name.toLowerCase().endsWith(".apk")) return name;
+        }
+        return "Navi-Link-v" + info.versionName + ".apk";
+    }
+
+    /** 简单清洗 markdown，使其在纯 TextView 中更易读（不做完整渲染）。 */
+    private static String cleanNotes(String md) {
+        if (TextUtils.isEmpty(md)) return "暂无更新说明";
+        String s = md.replace("\r\n", "\n");
+        StringBuilder out = new StringBuilder();
+        for (String line : s.split("\n")) {
+            String t = line.trim();
+            t = t.replaceAll("^#{1,6}\\s*", "");          // 标题
+            t = t.replaceAll("^[*\\-+]\\s+", "• ");        // 无序列表
+            t = t.replaceAll("\\*\\*(.+?)\\*\\*", "$1");   // 粗体
+            t = t.replaceAll("`([^`]+)`", "$1");            // 行内代码
+            out.append(t).append('\n');
+        }
+        return out.toString().trim();
+    }
+
+    private static String formatSize(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format(Locale.getDefault(), "%.1f KB", bytes / 1024.0);
+        return String.format(Locale.getDefault(), "%.1f MB", bytes / (1024.0 * 1024));
+    }
+}

--- a/app/src/main/res/drawable/bg_update_dialog.xml
+++ b/app/src/main/res/drawable/bg_update_dialog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 更新对话框圆角深色背景 -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FF1E1E1E" />
+    <corners android:radius="24dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#22FFFFFF" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -917,6 +917,60 @@
                             </HorizontalScrollView>
                         </LinearLayout>
                     </com.google.android.material.card.MaterialCardView>
+
+                    <!-- 关于 / 检查更新 -->
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/card_check_update"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        app:cardBackgroundColor="#FF1E1E1E"
+                        app:cardCornerRadius="16dp"
+                        app:cardElevation="0dp"
+                        app:strokeWidth="0dp"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:foreground="?android:attr/selectableItemBackground">
+
+                        <LinearLayout
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical"
+                            android:paddingHorizontal="16dp"
+                            android:paddingVertical="16dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+
+                            <LinearLayout
+                                android:orientation="vertical"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1">
+
+                                <TextView
+                                    android:text="检查更新"
+                                    android:textSize="15sp"
+                                    android:textColor="#FFFFFFFF"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content" />
+
+                                <TextView
+                                    android:id="@+id/tv_version_status"
+                                    android:text="当前版本"
+                                    android:textSize="12sp"
+                                    android:textColor="#FF888888"
+                                    android:layout_marginTop="2dp"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content" />
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="›"
+                                android:textSize="22sp"
+                                android:textColor="#FF666666" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
                 </LinearLayout>
             </ScrollView>
 

--- a/app/src/main/res/layout/dialog_update.xml
+++ b/app/src/main/res/layout/dialog_update.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 应用内更新提示对话框 -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@drawable/bg_update_dialog"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="26dp"
+    android:paddingBottom="18dp">
+
+    <!-- 顶部图标 + 标题 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🚀"
+            android:textSize="26sp"
+            android:layout_marginEnd="10dp" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="发现新版本"
+            android:textColor="#FFFFFFFF"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <!-- 版本号行 -->
+    <TextView
+        android:id="@+id/tv_update_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="v2.5.3  →  v2.5.4"
+        android:textColor="#FF4FC3F7"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <!-- APK 大小 -->
+    <TextView
+        android:id="@+id/tv_update_size"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="#FF888888"
+        android:textSize="12sp"
+        android:visibility="gone" />
+
+    <!-- 更新说明标题 -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="更新内容"
+        android:textColor="#FFBBBBBB"
+        android:textSize="13sp"
+        android:textStyle="bold" />
+
+    <!-- 更新说明（可滚动） -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:maxHeight="220dp"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false">
+
+        <TextView
+            android:id="@+id/tv_update_notes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="—"
+            android:textColor="#FFCCCCCC"
+            android:textSize="14sp"
+            android:lineSpacingExtra="3dp" />
+    </ScrollView>
+
+    <!-- 按钮区 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginTop="22dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_update_later"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="稍后再说"
+            android:textColor="#FF999999"
+            android:textSize="15sp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_update_now"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="立即更新"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            app:cornerRadius="14dp"
+            android:backgroundTint="#FF1199FF"
+            android:textColor="#FFFFFFFF" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- APK 下载到 cacheDir/apk 下，通过 FileProvider 暴露给安装器 -->
+    <cache-path
+        name="apk_cache"
+        path="apk/" />
+    <external-cache-path
+        name="apk_external_cache"
+        path="apk/" />
+</paths>

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,22 @@
+# ===== Navi-Link 服务端配置 =====
+# 复制为 .env 或直接设置环境变量。所有项均有默认值。
+
+# 监听端口
+PORT=3000
+
+# 监听地址（树莓派对外服务用 0.0.0.0，本地调试可用 127.0.0.1）
+HOST=0.0.0.0
+
+# GitHub 仓库（owner/repo）—— Release 数据来源
+GITHUB_REPO=shuhao1022/Navi-Link
+
+# GitHub Token（可选）。匿名调用 GitHub API 限流 60 次/小时，
+# 配置 token 后提升到 5000 次/小时。只需 public_repo 读权限。
+GITHUB_TOKEN=
+
+# Release 数据缓存时长（秒）。手动 /api/sync 可强制刷新。
+CACHE_TTL=600
+
+# APK 缓存目录。从 GitHub 拉取的安装包落盘于此，之后由本服务直接提供，
+# 客户端无需直连 GitHub。默认 server/.cache
+APK_CACHE_DIR=

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,8 @@
+# 依赖
+node_modules/
+
+# 本地配置
+.env
+
+# APK 下载缓存（运行时从 GitHub 拉取并落盘）
+.cache/

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,109 @@
+# Navi-Link 服务端（官网 + Release 更新 API）
+
+零依赖 Node.js 服务，部署在树莓派上：
+
+- **官网**：根路径 `/` 提供苹果液态玻璃风官网首页，动态展示最新版本与下载入口。
+- **更新 API**：供官网与 App 查询 GitHub 最新 Release，并代理缓存安装包下载。
+
+> App 与官网都通过**本服务**获取版本信息与安装包：本服务从 GitHub 拉取并在树莓派本地缓存，
+> 客户端无需直连 GitHub（国内网络更稳定）。App 中以编译期常量配置本服务地址，界面不展示该地址。
+
+---
+
+## 一、目录结构
+
+```
+server/
+├── server.js          # 主服务（仅用 Node 内置模块）
+├── package.json
+├── .env.example       # 配置样例
+└── public/            # 官网静态资源
+    ├── index.html
+    ├── styles.css     # 液态玻璃风样式
+    └── app.js
+```
+
+## 二、配置
+
+复制 `.env.example` 为 `.env` 并按需修改（也可直接用环境变量）：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `PORT` | `3000` | 监听端口 |
+| `HOST` | `0.0.0.0` | 监听地址 |
+| `GITHUB_REPO` | `shuhao1022/Navi-Link` | Release 数据来源仓库 |
+| `GITHUB_TOKEN` | 空 | 可选。配置后 GitHub API 限流从 60/h 提升到 5000/h |
+| `CACHE_TTL` | `600` | Release 缓存秒数；`/api/sync` 可强制刷新 |
+
+## 三、本地运行
+
+```bash
+cd server
+node server.js
+# 打开 http://127.0.0.1:3000
+```
+
+> **本地开发提示**：若你的网络环境使用企业自签 CA（代理），Node 直连 `api.github.com` 可能报
+> `unable to verify the first certificate`。此时用系统证书库启动即可：
+> ```bash
+> node --use-system-ca server.js
+> ```
+> 树莓派等正常环境无需此参数。
+
+## 四、API
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/api/latest` | 返回最新 Release（命中缓存则直接返回） |
+| `POST`/`GET` | `/api/sync` | 强制从 GitHub 拉取并刷新缓存 |
+| `GET`/`HEAD` | `/download/<文件名>` | APK 下载代理：本地有缓存直接发，否则从 GitHub 回源并落盘 |
+| `GET` | `/api/health` | 健康检查 |
+
+`/api/latest` 返回的 `apk.downloadUrl` 是**指向本服务**的相对地址（如 `/download/xxx.apk`），
+客户端据此下载，由本服务回源缓存；`apk.githubUrl` 为内部回源地址。
+
+返回示例（`/api/latest`）：
+
+```json
+{
+  "version": "v2.5.4",
+  "name": "Navi-Link v2.5.4",
+  "body": "更新日志（markdown）...",
+  "publishedAt": "2026-06-23T10:00:00Z",
+  "htmlUrl": "https://github.com/shuhao1022/Navi-Link/releases/tag/v2.5.4",
+  "prerelease": false,
+  "apk": {
+    "name": "Navi-Link-v2.5.4-release-xxx.apk",
+    "size": 12345678,
+    "downloadUrl": "/download/Navi-Link-v2.5.4-release-xxx.apk",
+    "githubUrl": "https://github.com/.../xxx.apk",
+    "downloadCount": 42
+  },
+  "assets": [ ... ],
+  "_cache": "hit | miss | refreshed | stale"
+}
+```
+
+## 五、树莓派部署（systemd）
+
+1. 拷贝 `server/` 到树莓派，例如 `/opt/navi-link/server`。
+2. 安装 Node ≥18（`sudo apt install nodejs npm` 或用 nvm）。
+3. 配置 `.env`。
+4. 安装 systemd 服务：
+
+```bash
+sudo cp navi-link.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now navi-link
+sudo systemctl status navi-link
+```
+
+5. 配合反向代理（Nginx/Caddy）将 `navi-link.zuoqirun.top` 指向 `127.0.0.1:3000`，并启用 HTTPS。
+
+Caddy 示例（自动 HTTPS）：
+
+```
+navi-link.zuoqirun.top {
+    reverse_proxy 127.0.0.1:3000
+}
+```

--- a/server/navi-link.service
+++ b/server/navi-link.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Navi-Link 官网与 Release 更新 API 服务
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# 按实际部署路径修改
+WorkingDirectory=/opt/navi-link/server
+ExecStart=/usr/bin/node server.js
+Restart=on-failure
+RestartSec=5
+# 通过 .env 读取配置；也可在此用 Environment= 覆盖
+# Environment=PORT=3000
+# Environment=GITHUB_TOKEN=ghp_xxx
+User=pi
+Group=pi
+# 安全加固
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "navi-link-server",
+  "version": "1.0.0",
+  "description": "Navi-Link 官网与 Release 更新 API 服务（树莓派部署）",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -1,0 +1,216 @@
+/**
+ * Navi-Link 官网前端脚本
+ * ─────────────────────────────────────────────────
+ * - 从 /api/latest 获取最新 release 信息
+ * - 动态渲染下载按钮、版本号、更新日志
+ * - 手动同步按钮逻辑
+ * - 滚动入场动效
+ */
+
+(function () {
+  'use strict';
+
+  // ── 液态玻璃折射门控 ─────────────────────────────────
+  // 真折射(SVG backdrop-filter:url) 仅 Chromium 生效，且开销大。
+  // 只在 Chromium + 桌面/高端 + 未要求降级时启用，车机/移动端停留在基线毛玻璃。
+  (function gateLiquid() {
+    try {
+      const ua = navigator.userAgent;
+      const isChromium = (!!window.chrome && !/Edg|OPR/.test(ua)) ||
+        (/Chrome\/\d+/.test(ua) && !/\bVersion\/[\d.]+\b/.test(ua));
+      const cores = navigator.hardwareConcurrency || 2;
+      const mem = navigator.deviceMemory || 2;
+      const desktop = window.matchMedia('(pointer:fine)').matches;
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+        window.matchMedia('(prefers-reduced-transparency: reduce)').matches;
+      if (isChromium && desktop && cores >= 4 && mem >= 4 && !reduce) {
+        document.documentElement.classList.add('has-liquid');
+      }
+    } catch (e) {
+      /* 探测失败则保持基线毛玻璃 */
+    }
+  })();
+
+  // ── DOM refs ────────────────────────────────────────
+  const $ = (sel) => document.querySelector(sel);
+
+  const refs = {
+    heroVersion: $('#hero-version-tag'),
+    heroDownload: $('#hero-download'),
+    heroDownloadText: $('#hero-download-text'),
+    downloadMeta: $('#download-meta'),
+    downloadBtn: $('#download-btn'),
+    downloadBtnText: $('#download-btn-text'),
+    downloadSize: $('#download-size'),
+    downloadCount: $('#download-count'),
+    releaseLoading: $('#release-loading'),
+    releaseContent: $('#release-content'),
+    releaseError: $('#release-error'),
+    releaseTitle: $('#release-title'),
+    releaseDate: $('#release-date'),
+    releaseNotes: $('#release-notes'),
+    syncBtn: $('#sync-btn'),
+    syncText: $('#sync-text'),
+    syncStatus: $('#sync-status'),
+    year: $('#year'),
+  };
+
+  // ── 初始化 ──────────────────────────────────────────
+  if (refs.year) refs.year.textContent = new Date().getFullYear();
+  initRevealObserver();
+  loadRelease(false);
+  if (refs.syncBtn) refs.syncBtn.addEventListener('click', () => loadRelease(true));
+
+  // ── 加载 release 数据 ────────────────────────────────
+  async function loadRelease(force) {
+    setSyncing(force);
+    try {
+      const url = force ? '/api/sync' : '/api/latest';
+      const resp = await fetch(url, { method: force ? 'POST' : 'GET' });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+
+      if (data.error) throw new Error(data.message || data.error);
+      renderRelease(data);
+      if (force) showSyncStatus('✓ 同步成功', 'ok');
+    } catch (err) {
+      showError(err.message);
+      if (force) showSyncStatus(`✗ 同步失败: ${err.message}`, 'err');
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  // ── 渲染 release 信息到页面 ────────────────────────────
+  function renderRelease(data) {
+    const version = data.version || '未知版本';
+    const name = data.name || version;
+    const apk = data.apk;
+    const pub = data.publishedAt;
+
+    // Hero
+    if (refs.heroVersion) refs.heroVersion.textContent = `最新发布 ${version}`;
+    if (refs.heroDownloadText) refs.heroDownloadText.textContent = `下载 ${version}`;
+    if (apk) {
+      setDownloadLink(refs.heroDownload, apk.downloadUrl);
+    }
+
+    // Download card
+    if (refs.downloadMeta) refs.downloadMeta.textContent = `${name}  ·  ${formatDate(pub)}`;
+    if (refs.downloadBtnText) refs.downloadBtnText.textContent = apk ? `下载 ${version} (.apk)` : `前往 Release 页面`;
+    if (refs.downloadBtn) {
+      setDownloadLink(refs.downloadBtn, apk ? apk.downloadUrl : data.htmlUrl);
+      refs.downloadBtn.removeAttribute('aria-disabled');
+    }
+    if (refs.downloadSize && apk) refs.downloadSize.textContent = `大小 ${formatSize(apk.size)}`;
+    if (refs.downloadCount && apk) refs.downloadCount.textContent = `下载次数 ${apk.downloadCount}`;
+
+    // Release notes
+    if (refs.releaseLoading) refs.releaseLoading.hidden = true;
+    if (refs.releaseError) refs.releaseError.hidden = true;
+    if (refs.releaseContent) refs.releaseContent.hidden = false;
+    if (refs.releaseTitle) refs.releaseTitle.textContent = name;
+    if (refs.releaseDate) refs.releaseDate.textContent = formatDate(pub);
+    if (refs.releaseNotes) refs.releaseNotes.innerHTML = markdownToHtml(data.body || '暂无更新说明');
+  }
+
+  function showError(msg) {
+    if (refs.releaseLoading) refs.releaseLoading.hidden = true;
+    if (refs.releaseContent) refs.releaseContent.hidden = true;
+    if (refs.releaseError) {
+      refs.releaseError.hidden = false;
+      refs.releaseError.textContent = msg || '加载失败';
+    }
+    if (refs.heroVersion) refs.heroVersion.textContent = '暂无版本信息';
+  }
+
+  // ── 同步按钮状态 ────────────────────────────────────
+  function setSyncing(active) {
+    if (!refs.syncBtn) return;
+    refs.syncBtn.classList.toggle('spinning', active);
+    refs.syncBtn.disabled = active;
+    if (refs.syncText) refs.syncText.textContent = active ? '同步中…' : '手动同步';
+  }
+
+  function showSyncStatus(msg, type) {
+    if (!refs.syncStatus) return;
+    refs.syncStatus.textContent = msg;
+    refs.syncStatus.style.color = type === 'ok' ? '#30d158' : type === 'err' ? '#ff6b6b' : '';
+    clearTimeout(showSyncStatus._t);
+    showSyncStatus._t = setTimeout(() => { refs.syncStatus.textContent = ''; }, 4000);
+  }
+
+  // ── 工具 ────────────────────────────────────────────
+  function setDownloadLink(el, url) {
+    if (!el || !url) return;
+    el.href = url;
+    el.target = '_blank';
+    el.rel = 'noopener';
+  }
+
+  function formatDate(iso) {
+    if (!iso) return '';
+    try {
+      const d = new Date(iso);
+      return d.toLocaleDateString('zh-CN', { year: 'numeric', month: 'long', day: 'numeric' });
+    } catch {
+      return iso.slice(0, 10);
+    }
+  }
+
+  function formatSize(bytes) {
+    if (!bytes) return '';
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / 1048576).toFixed(1) + ' MB';
+  }
+
+  /** 极简 markdown → HTML（支持 h1-h3, bold, code, links, lists, paragraphs） */
+  function markdownToHtml(md) {
+    let html = md
+      // code blocks (fenced)
+      .replace(/```[\s\S]*?```/g, (m) => `<pre><code>${esc(m.slice(3, -3).trim())}</code></pre>`)
+      // inline code
+      .replace(/`([^`]+)`/g, '<code>$1</code>')
+      // headings
+      .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+      .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+      .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+      // bold
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      // links
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+      // unordered list
+      .replace(/^[*\-+] (.+)$/gm, '<li>$1</li>')
+      // paragraphs
+      .replace(/\n{2,}/g, '</p><p>');
+
+    // wrap loose <li> in <ul>
+    html = html.replace(/((?:<li>.*<\/li>\s*)+)/g, '<ul>$1</ul>');
+    return '<p>' + html + '</p>';
+  }
+
+  function esc(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  // ── 滚动入场动效 ────────────────────────────────────
+  function initRevealObserver() {
+    // 给所有 feature / download / release 区域加 reveal class
+    document.querySelectorAll('.feature, .download-card, .release-card').forEach((el) => {
+      el.classList.add('reveal');
+    });
+
+    if (!('IntersectionObserver' in window)) {
+      // 降级：直接显示
+      document.querySelectorAll('.reveal').forEach((el) => el.classList.add('in'));
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } }),
+      { threshold: 0.15 }
+    );
+    document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+  }
+})();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Navi-Link · 让导航无界连接</title>
+  <meta name="description" content="Navi-Link —— 车机导航悬浮窗助手。极简灵动岛、车道级引导、红绿灯倒计时，与高德地图无缝联动。" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%A7%AD%3C/text%3E%3C/svg%3E" />
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <!-- 流动光斑背景 -->
+  <div class="aurora">
+    <span class="blob blob-1"></span>
+    <span class="blob blob-2"></span>
+    <span class="blob blob-3"></span>
+    <span class="blob blob-4"></span>
+  </div>
+
+  <!-- 顶部玻璃导航 -->
+  <header class="glass-nav liquid" id="nav">
+    <a class="brand" href="#top">
+      <span class="brand-mark">🧭</span>
+      <span class="brand-name">Navi-Link</span>
+    </a>
+    <nav class="nav-links">
+      <a href="#features">特性</a>
+      <a href="#download">下载</a>
+      <a href="#release">更新</a>
+    </nav>
+    <a class="nav-cta" href="#download">立即获取</a>
+  </header>
+
+  <main id="top">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="hero-badge glass-pill">
+        <span class="dot"></span>
+        <span id="hero-version-tag">正在获取最新版本…</span>
+      </div>
+      <h1 class="hero-title">
+        让导航<span class="grad-text">无界连接</span>
+      </h1>
+      <p class="hero-sub">
+        车机悬浮窗导航助手。灵动岛式极简界面、车道级引导、红绿灯倒计时，<br />
+        与高德地图无缝联动，把每一段旅程都映在眼前。
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" id="hero-download" href="#download">
+          <span class="btn-icon">⬇</span>
+          <span id="hero-download-text">下载最新版</span>
+        </a>
+        <a class="btn btn-ghost" href="#features">了解特性</a>
+      </div>
+
+      <!-- 设备预览玻璃卡 -->
+      <div class="hero-preview glass-card liquid">
+        <div class="preview-screen">
+          <div class="island">
+            <div class="island-turn">↰</div>
+            <div class="island-info">
+              <div class="island-road">中山北路</div>
+              <div class="island-dist">还有 <b>320</b> 米</div>
+            </div>
+            <div class="island-light">
+              <span class="light-num">12</span>
+            </div>
+          </div>
+          <div class="preview-lanes">
+            <span class="lane on">⬆</span>
+            <span class="lane">⬈</span>
+            <span class="lane">⬆</span>
+            <span class="lane on">↱</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 特性 -->
+    <section class="features" id="features">
+      <h2 class="section-title">为驾驶而生的细节</h2>
+      <div class="feature-grid">
+        <article class="glass-card feature">
+          <div class="feature-ico">🪟</div>
+          <h3>灵动岛悬浮窗</h3>
+          <p>极简、标准、完整三种样式，悬浮于任意车机界面之上，随心切换。</p>
+        </article>
+        <article class="glass-card feature">
+          <div class="feature-ico">🛣️</div>
+          <h3>车道级引导</h3>
+          <p>实时车道线渲染，清晰指示推荐车道，复杂路口也从容应对。</p>
+        </article>
+        <article class="glass-card feature">
+          <div class="feature-ico">🚦</div>
+          <h3>红绿灯倒计时</h3>
+          <p>路口信号灯读秒一目了然，起步停车更有底。</p>
+        </article>
+        <article class="glass-card feature">
+          <div class="feature-ico">📟</div>
+          <h3>仪表盘镜像</h3>
+          <p>可投射至副屏 / 仪表盘，导航信息与驾驶视线同在。</p>
+        </article>
+        <article class="glass-card feature">
+          <div class="feature-ico">⚡</div>
+          <h3>开机自启</h3>
+          <p>上车即用，连接电源自动唤起服务，无需手动开启。</p>
+        </article>
+        <article class="glass-card feature">
+          <div class="feature-ico">🎨</div>
+          <h3>主题随心</h3>
+          <p>多种主色调与背景透明度，融入你的座舱风格。</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- 下载 -->
+    <section class="download" id="download">
+      <div class="glass-card liquid download-card">
+        <h2 class="section-title">立即下载</h2>
+        <p class="download-meta" id="download-meta">正在获取最新版本信息…</p>
+        <a class="btn btn-primary btn-lg" id="download-btn" href="#" aria-disabled="true">
+          <span class="btn-icon">⬇</span>
+          <span id="download-btn-text">获取中…</span>
+        </a>
+        <div class="download-extra">
+          <span id="download-size"></span>
+          <span id="download-count"></span>
+        </div>
+        <p class="download-hint">下载完成后，在车机上安装即可。需开启「允许安装未知来源应用」。</p>
+      </div>
+    </section>
+
+    <!-- 最新发布 / 更新日志 -->
+    <section class="release" id="release">
+      <div class="release-head">
+        <h2 class="section-title">最新发布</h2>
+        <button class="btn btn-ghost btn-sync" id="sync-btn" title="强制从 GitHub 同步最新发布">
+          <span class="sync-icon">⟳</span>
+          <span id="sync-text">手动同步</span>
+        </button>
+      </div>
+      <div class="glass-card liquid release-card" id="release-card">
+        <div class="release-loading" id="release-loading">正在加载发布信息…</div>
+        <div class="release-content" id="release-content" hidden>
+          <div class="release-title-row">
+            <h3 id="release-title">—</h3>
+            <span class="release-date glass-pill" id="release-date"></span>
+          </div>
+          <div class="release-notes markdown" id="release-notes"></div>
+        </div>
+        <div class="release-error" id="release-error" hidden></div>
+      </div>
+      <p class="sync-status" id="sync-status"></p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <span class="brand-mark">🧭</span>
+      <span>Navi-Link</span>
+      <span class="footer-dot">·</span>
+      <span>让导航无界连接</span>
+    </div>
+    <p class="footer-copy">© <span id="year"></span> Navi-Link Project</p>
+  </footer>
+
+  <!-- 液态玻璃 SVG 折射滤镜：尺寸为 0 但仍在文档流中（不能 display:none，否则引用失效）。
+       仅 Chromium 内核 + 高端设备会通过 JS 门控启用（<html class="has-liquid"）；
+       Safari/Firefox 不支持 backdrop-filter:url()，自动退化为纯模糊。 -->
+  <svg width="0" height="0" aria-hidden="true"
+       style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <filter id="liquid-glass"
+              x="-25%" y="-25%" width="150%" height="150%"
+              filterUnits="objectBoundingBox"
+              color-interpolation-filters="sRGB">
+        <!-- 低频柔和噪声（玻璃用 fractalNoise） -->
+        <feTurbulence type="fractalNoise"
+                      baseFrequency="0.009 0.013"
+                      numOctaves="2"
+                      seed="9"
+                      stitchTiles="stitch"
+                      result="noise" />
+        <!-- 中性灰 #808080 = 通道值 0.5 = 零位移（中心保持清晰） -->
+        <feFlood flood-color="#808080" result="flat" />
+        <!-- 径向遮罩：中心黑（不动）、边缘白（强折射）。# 与 % 须编码为 %23 / %25 -->
+        <feImage result="edgeMask"
+          xlink:href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='200'><radialGradient id='r' cx='50%25' cy='50%25' r='60%25'><stop offset='42%25' stop-color='black'/><stop offset='100%25' stop-color='white'/></radialGradient><rect width='100%25' height='100%25' fill='url(%23r)'/></svg>" />
+        <!-- 边缘保留噪声、中心归零，合成「边缘强、中心弱」位移图 -->
+        <feComposite in="noise" in2="edgeMask" operator="in" result="edgeNoise" />
+        <feMerge result="dispMap">
+          <feMergeNode in="flat" />
+          <feMergeNode in="edgeNoise" />
+        </feMerge>
+        <!-- 折射：X 用 R 通道、Y 用 G 通道 -->
+        <feDisplacementMap in="SourceGraphic" in2="dispMap"
+                           scale="26"
+                           xChannelSelector="R" yChannelSelector="G"
+                           result="displaced" />
+        <!-- 折射后补一点磨砂，统一质感 -->
+        <feGaussianBlur in="displaced" stdDeviation="0.5" />
+      </filter>
+    </defs>
+  </svg>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -1,0 +1,530 @@
+/* ════════════════════════════════════════════════════════════════
+   Navi-Link 官网 · 苹果液态玻璃风 (Liquid Glass)
+   ════════════════════════════════════════════════════════════════ */
+
+:root {
+  --bg: #060810;
+  --glass-bg: rgba(255, 255, 255, 0.07);
+  --glass-bg-strong: rgba(255, 255, 255, 0.12);
+  --glass-border: rgba(255, 255, 255, 0.18);
+  --glass-hi: rgba(255, 255, 255, 0.55);
+  --text: #f5f7fa;
+  --text-dim: rgba(245, 247, 250, 0.62);
+  --text-faint: rgba(245, 247, 250, 0.38);
+  --accent: #5ac8fa;
+  --accent-2: #0a84ff;
+  --accent-3: #bf5af2;
+  --accent-4: #ff9f0a;
+  --radius: 26px;
+  --radius-sm: 16px;
+  --shadow: 0 8px 40px rgba(0, 0, 0, 0.4);
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --nav-h: 64px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--nav-h) + 16px);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+    "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: 0.01em;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ── 流动极光背景 ──────────────────────────────────────────── */
+.aurora {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  overflow: hidden;
+  background: radial-gradient(ellipse at 50% -20%, #122 0%, var(--bg) 60%);
+}
+.blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.55;
+  will-change: transform;
+}
+.blob-1 {
+  width: 46vw; height: 46vw;
+  background: radial-gradient(circle, var(--accent-2), transparent 70%);
+  top: -8vw; left: -6vw;
+  animation: drift1 22s var(--ease) infinite alternate;
+}
+.blob-2 {
+  width: 40vw; height: 40vw;
+  background: radial-gradient(circle, var(--accent-3), transparent 70%);
+  top: 10vh; right: -10vw;
+  animation: drift2 26s var(--ease) infinite alternate;
+}
+.blob-3 {
+  width: 38vw; height: 38vw;
+  background: radial-gradient(circle, var(--accent), transparent 70%);
+  bottom: -10vw; left: 20vw;
+  animation: drift3 30s var(--ease) infinite alternate;
+}
+.blob-4 {
+  width: 30vw; height: 30vw;
+  background: radial-gradient(circle, var(--accent-4), transparent 70%);
+  bottom: 5vh; right: 15vw;
+  opacity: 0.35;
+  animation: drift1 28s var(--ease) infinite alternate-reverse;
+}
+@keyframes drift1 { to { transform: translate(8vw, 10vh) scale(1.15); } }
+@keyframes drift2 { to { transform: translate(-10vw, 6vh) scale(1.1); } }
+@keyframes drift3 { to { transform: translate(6vw, -8vh) scale(1.2); } }
+
+/* ── 玻璃基类（液态玻璃：轻模糊 + 镜面描边 + 厚度，折射作为 Chromium 叠加层）── */
+.glass-card,
+.glass-nav,
+.glass-pill {
+  background: var(--glass-bg);
+  /* 折射才是主角，模糊比传统毛玻璃轻，重模糊会盖掉折射感 */
+  backdrop-filter: blur(14px) saturate(165%);
+  -webkit-backdrop-filter: blur(14px) saturate(165%);
+  border: 1px solid var(--glass-border);
+  isolation: isolate; /* 独立合成层，避免与背景流光动画混合异常 */
+}
+
+.glass-card {
+  border-radius: var(--radius);
+  box-shadow: var(--shadow),
+    inset 0 1px 0 0 var(--glass-hi),
+    inset 0 -1px 1px 0 rgba(0, 0, 0, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+/* 顶部高光弧 —— 玻璃顶面的 sheen */
+.glass-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    160deg,
+    rgba(255, 255, 255, 0.18) 0%,
+    rgba(255, 255, 255, 0) 38%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+/* 镜面渐变描边（specular highlight）—— 液态玻璃的关键：1px 倒角镜边，
+   135° 左上最亮、右下次亮、中段透明，像光线掠过玻璃边缘的高光。 */
+.glass-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.75),
+    rgba(255, 255, 255, 0) 38%,
+    rgba(255, 255, 255, 0) 62%,
+    rgba(255, 255, 255, 0.4)
+  );
+  -webkit-mask: linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude; /* 只保留 1px 描边 */
+  pointer-events: none;
+  z-index: 2;
+}
+
+.glass-pill {
+  border-radius: 999px;
+  box-shadow: inset 0 1px 0 0 var(--glass-hi);
+}
+
+/* ── 折射叠加：仅 Chromium + 高端设备（<html class="has-liquid"），
+      给元素加 .liquid 类启用真折射。Safari/旧浏览器 -webkit- 不接受 url()，
+      自动只剩模糊，即优雅退化。 ───────────────────────────────────── */
+.has-liquid .glass-card.liquid,
+.has-liquid .glass-nav.liquid {
+  backdrop-filter: url(#liquid-glass) blur(10px) saturate(165%);
+  -webkit-backdrop-filter: blur(14px) saturate(165%);
+}
+
+/* ── 顶部导航 ──────────────────────────────────────────────── */
+.glass-nav {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(1100px, calc(100% - 24px));
+  height: var(--nav-h);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 0 12px 0 22px;
+  border-radius: 999px;
+  box-shadow: var(--shadow), inset 0 1px 0 0 var(--glass-hi);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.02em;
+}
+.brand-mark { font-size: 20px; }
+.nav-links {
+  display: flex;
+  gap: 26px;
+  margin-left: auto;
+  font-size: 15px;
+  color: var(--text-dim);
+}
+.nav-links a { transition: color 0.25s; }
+.nav-links a:hover { color: var(--text); }
+.nav-cta {
+  padding: 9px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #021;
+  box-shadow: 0 4px 16px rgba(10, 132, 255, 0.4),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.5);
+  transition: transform 0.25s var(--ease), box-shadow 0.25s;
+}
+.nav-cta:hover { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(10, 132, 255, 0.55); }
+
+/* ── 通用区块 ──────────────────────────────────────────────── */
+main { max-width: 1100px; margin: 0 auto; padding: 0 16px; }
+section { padding: 92px 0; }
+.section-title {
+  font-size: clamp(26px, 4vw, 38px);
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: -0.01em;
+  margin-bottom: 14px;
+}
+
+/* ── HERO ──────────────────────────────────────────────────── */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding-top: calc(var(--nav-h) + 60px);
+  gap: 22px;
+}
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 16px;
+  font-size: 13px;
+  color: var(--text-dim);
+  animation: fadeUp 0.8s var(--ease) both;
+}
+.hero-badge .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #30d158;
+  box-shadow: 0 0 10px #30d158;
+  animation: pulse 2s infinite;
+}
+@keyframes pulse { 50% { opacity: 0.4; } }
+
+.hero-title {
+  font-size: clamp(44px, 8vw, 84px);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  animation: fadeUp 0.8s 0.1s var(--ease) both;
+}
+.grad-text {
+  background: linear-gradient(120deg, var(--accent), var(--accent-3) 60%, var(--accent-4));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.hero-sub {
+  max-width: 620px;
+  font-size: clamp(15px, 2.2vw, 19px);
+  color: var(--text-dim);
+  animation: fadeUp 0.8s 0.2s var(--ease) both;
+}
+.hero-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+  animation: fadeUp 0.8s 0.3s var(--ease) both;
+}
+
+/* ── 按钮 ──────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 13px 26px;
+  border-radius: 999px;
+  font-size: 15px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.25s var(--ease), box-shadow 0.25s, background 0.25s, opacity 0.25s;
+  white-space: nowrap;
+}
+.btn-icon { font-size: 16px; }
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #021;
+  box-shadow: 0 6px 22px rgba(10, 132, 255, 0.45),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.5);
+}
+.btn-primary:hover { transform: translateY(-2px); box-shadow: 0 12px 30px rgba(10, 132, 255, 0.6), inset 0 1px 0 0 rgba(255,255,255,0.5); }
+.btn-primary[aria-disabled="true"] { opacity: 0.5; pointer-events: none; filter: grayscale(0.3); }
+.btn-ghost {
+  background: var(--glass-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-color: var(--glass-border);
+  color: var(--text);
+  box-shadow: inset 0 1px 0 0 var(--glass-hi);
+}
+.btn-ghost:hover { background: var(--glass-bg-strong); transform: translateY(-2px); }
+.btn-lg { padding: 16px 36px; font-size: 17px; }
+
+/* ── HERO 预览玻璃卡 ───────────────────────────────────────── */
+.hero-preview {
+  margin-top: 38px;
+  width: min(520px, 92%);
+  padding: 28px;
+  animation: fadeUp 1s 0.45s var(--ease) both, float 6s ease-in-out 1.4s infinite;
+}
+@keyframes float { 50% { transform: translateY(-10px); } }
+.preview-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: center;
+}
+.island {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 20px;
+  border-radius: 22px;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.12);
+}
+.island-turn {
+  font-size: 30px;
+  color: var(--accent);
+  text-shadow: 0 0 14px var(--accent);
+}
+.island-info { flex: 1; text-align: left; }
+.island-road { font-size: 17px; font-weight: 600; }
+.island-dist { font-size: 13px; color: var(--text-dim); }
+.island-dist b { color: var(--accent); font-size: 15px; }
+.island-light {
+  width: 46px; height: 46px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 40% 35%, #ff5b5b, #c70d0d);
+  box-shadow: 0 0 18px rgba(255, 80, 80, 0.7), inset 0 2px 4px rgba(255,255,255,0.4);
+}
+.light-num { font-size: 20px; font-weight: 700; color: #fff; }
+.preview-lanes {
+  display: flex;
+  gap: 12px;
+}
+.lane {
+  width: 40px; height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-faint);
+}
+.lane.on {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #021;
+  box-shadow: 0 0 16px rgba(90, 200, 250, 0.6);
+}
+
+/* ── 特性栅格 ──────────────────────────────────────────────── */
+.feature-grid {
+  margin-top: 44px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+.feature {
+  padding: 30px 26px;
+  transition: transform 0.35s var(--ease), box-shadow 0.35s;
+}
+.feature:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow), 0 18px 50px rgba(10, 132, 255, 0.25), inset 0 1px 0 0 var(--glass-hi);
+}
+.feature-ico {
+  font-size: 34px;
+  margin-bottom: 14px;
+  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4));
+}
+.feature h3 { font-size: 19px; margin-bottom: 8px; }
+.feature p { font-size: 14.5px; color: var(--text-dim); }
+
+/* ── 下载区 ────────────────────────────────────────────────── */
+.download-card {
+  padding: 50px 36px;
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.download-meta { color: var(--text-dim); margin-bottom: 26px; font-size: 15px; }
+.download-extra {
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+  margin-top: 18px;
+  font-size: 13px;
+  color: var(--text-faint);
+}
+.download-hint {
+  margin-top: 22px;
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+
+/* ── 发布 / 更新日志 ───────────────────────────────────────── */
+.release-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.release-head .section-title { text-align: left; margin: 0; }
+.btn-sync { padding: 10px 18px; font-size: 14px; }
+.sync-icon { display: inline-block; font-size: 16px; transition: transform 0.6s var(--ease); }
+.btn-sync.spinning .sync-icon { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.release-card { padding: 32px 30px; min-height: 120px; }
+.release-loading, .release-error { color: var(--text-dim); text-align: center; padding: 20px; }
+.release-error { color: #ff6b6b; }
+.release-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.release-title-row h3 { font-size: 22px; }
+.release-date { padding: 5px 14px; font-size: 13px; color: var(--text-dim); }
+.sync-status {
+  text-align: center;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text-faint);
+  min-height: 18px;
+  transition: color 0.3s;
+}
+
+/* 简易 markdown 渲染 */
+.markdown { font-size: 14.5px; color: var(--text-dim); }
+.markdown h1, .markdown h2, .markdown h3 { color: var(--text); margin: 16px 0 8px; font-size: 17px; }
+.markdown ul { padding-left: 22px; margin: 8px 0; }
+.markdown li { margin: 4px 0; }
+.markdown p { margin: 8px 0; }
+.markdown code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.9em;
+}
+.markdown a { color: var(--accent); }
+.markdown strong { color: var(--text); }
+
+/* ── 页脚 ──────────────────────────────────────────────────── */
+.footer {
+  text-align: center;
+  padding: 50px 16px 60px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 16px;
+}
+.footer-dot { color: var(--text-faint); }
+.footer-copy { margin-top: 8px; font-size: 13px; color: var(--text-faint); }
+
+/* ── 入场动画 ──────────────────────────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.reveal { opacity: 0; transform: translateY(30px); transition: opacity 0.7s var(--ease), transform 0.7s var(--ease); }
+.reveal.in { opacity: 1; transform: translateY(0); }
+
+/* ── 响应式 ────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .nav-links { display: none; }
+  section { padding: 64px 0; }
+  .hero { padding-top: calc(var(--nav-h) + 30px); }
+}
+
+/* 降级：不支持 backdrop-filter 时用实色 */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass-card, .glass-nav, .glass-pill, .btn-ghost {
+    background: rgba(22, 26, 38, 0.92);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .glass-card::after { display: none; }
+}
+
+/* 无障碍/省电：用户要求减少透明 → 退实色并关折射 */
+@media (prefers-reduced-transparency: reduce) {
+  .glass-card, .glass-nav, .glass-pill, .btn-ghost {
+    background: rgba(22, 26, 38, 0.92);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .has-liquid .glass-card.liquid,
+  .has-liquid .glass-nav.liquid { backdrop-filter: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+  html { scroll-behavior: auto; }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,400 @@
+/**
+ * Navi-Link 服务端
+ * ─────────────────────────────────────────────────────────────
+ * 职责：
+ *   1. 托管官网静态页面（public/ 目录，苹果液态玻璃风）
+ *   2. 提供 Release 更新 API：
+ *        GET /api/latest  —— 返回 GitHub 最新 release（带缓存）
+ *        POST /api/sync   —— 手动强制刷新缓存
+ *        GET /api/health  —— 健康检查
+ *
+ * 设计：仅依赖 Node 内置模块，方便在树莓派上零依赖部署。
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── 配置（环境变量优先，含默认值）──────────────────────────────
+loadDotEnv(path.join(__dirname, '.env'));
+
+const CONFIG = {
+  port: parseInt(process.env.PORT || '3000', 10),
+  host: process.env.HOST || '0.0.0.0',
+  repo: process.env.GITHUB_REPO || 'shuhao1022/Navi-Link',
+  token: process.env.GITHUB_TOKEN || '',
+  cacheTtl: parseInt(process.env.CACHE_TTL || '600', 10) * 1000,
+  // APK 缓存目录：从 GitHub 拉取的安装包落盘于此，之后由树莓派直接提供，
+  // 避免客户端直连 GitHub（国内不稳定）。
+  apkCacheDir: process.env.APK_CACHE_DIR || path.join(__dirname, '.cache'),
+};
+
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+// 确保 APK 缓存目录存在
+try {
+  fs.mkdirSync(CONFIG.apkCacheDir, { recursive: true });
+} catch (e) {
+  console.warn('[WARN] 无法创建 APK 缓存目录:', e.message);
+}
+
+// ── Release 缓存 ────────────────────────────────────────────────
+const cache = {
+  data: null,        // 规范化后的 release 对象
+  fetchedAt: 0,      // 上次抓取时间戳（ms）
+  raw: null,         // GitHub 原始响应（调试用）
+};
+
+// ── HTTP 服务 ──────────────────────────────────────────────────
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = decodeURIComponent(url.pathname);
+
+  // 统一 CORS（官网前端 fetch 用）
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  try {
+    if (pathname === '/api/latest' && req.method === 'GET') {
+      return await handleLatest(req, res, false);
+    }
+    if (pathname === '/api/sync' && (req.method === 'POST' || req.method === 'GET')) {
+      return await handleLatest(req, res, true);
+    }
+    if (pathname === '/api/health' && req.method === 'GET') {
+      return sendJson(res, 200, {
+        status: 'ok',
+        repo: CONFIG.repo,
+        cached: !!cache.data,
+        cacheAgeSec: cache.fetchedAt ? Math.round((Date.now() - cache.fetchedAt) / 1000) : null,
+      });
+    }
+    // APK 下载代理：/download/<文件名> —— 优先本地缓存，未命中则从 GitHub 拉取并落盘
+    if (pathname.startsWith('/download/') && (req.method === 'GET' || req.method === 'HEAD')) {
+      return await handleDownload(pathname, req, res);
+    }
+    // 其余交给静态文件服务（官网）
+    return serveStatic(pathname, res);
+  } catch (err) {
+    console.error('[ERROR]', err);
+    sendJson(res, 500, { error: 'internal_error', message: String(err && err.message || err) });
+  }
+});
+
+server.listen(CONFIG.port, CONFIG.host, () => {
+  console.log(`\n  Navi-Link 服务已启动`);
+  console.log(`  ├─ 监听地址 : http://${CONFIG.host}:${CONFIG.port}`);
+  console.log(`  ├─ 仓库     : ${CONFIG.repo}`);
+  console.log(`  ├─ 缓存时长 : ${CONFIG.cacheTtl / 1000}s`);
+  console.log(`  ├─ Token    : ${CONFIG.token ? '已配置' : '匿名（限流 60/h）'}`);
+  console.log(`  ├─ APK 缓存 : ${CONFIG.apkCacheDir}`);
+  console.log(`  └─ 官网目录 : ${PUBLIC_DIR}\n`);
+});
+
+// ── 处理 /api/latest 与 /api/sync ──────────────────────────────
+async function handleLatest(req, res, forceRefresh) {
+  const fresh = !forceRefresh && cache.data && (Date.now() - cache.fetchedAt) < CONFIG.cacheTtl;
+
+  if (fresh) {
+    return sendJson(res, 200, { ...cache.data, _cache: 'hit', _ageSec: Math.round((Date.now() - cache.fetchedAt) / 1000) });
+  }
+
+  try {
+    const release = await fetchLatestRelease();
+    cache.data = release;
+    cache.fetchedAt = Date.now();
+    return sendJson(res, 200, { ...release, _cache: forceRefresh ? 'refreshed' : 'miss' });
+  } catch (err) {
+    // 抓取失败时，若有旧缓存则降级返回旧数据，保证可用性
+    if (cache.data) {
+      return sendJson(res, 200, { ...cache.data, _cache: 'stale', _warning: String(err.message || err) });
+    }
+    const code = err.statusCode === 404 ? 404 : 502;
+    return sendJson(res, code, { error: 'fetch_failed', message: String(err.message || err) });
+  }
+}
+
+// ── 抓取并规范化 GitHub 最新 release ───────────────────────────
+async function fetchLatestRelease() {
+  const apiPath = `/repos/${CONFIG.repo}/releases/latest`;
+  const body = await githubGet(apiPath);
+  const r = JSON.parse(body);
+
+  // 找出 APK 资产
+  const assets = Array.isArray(r.assets) ? r.assets : [];
+  const apk = assets.find((a) => /\.apk$/i.test(a.name)) || null;
+
+  return {
+    version: r.tag_name || r.name || '',
+    name: r.name || r.tag_name || '',
+    body: r.body || '',
+    publishedAt: r.published_at || '',
+    htmlUrl: r.html_url || '',
+    prerelease: !!r.prerelease,
+    apk: apk
+      ? {
+          name: apk.name,
+          size: apk.size,
+          // downloadUrl：客户端使用的地址，指向本服务器的下载代理（相对路径），
+          // 由树莓派缓存并提供，客户端无需直连 GitHub。
+          downloadUrl: '/download/' + encodeURIComponent(apk.name),
+          // githubUrl：真实回源地址，仅服务端下载代理内部使用。
+          githubUrl: apk.browser_download_url,
+          downloadCount: apk.download_count,
+        }
+      : null,
+    assets: assets.map((a) => ({
+      name: a.name,
+      size: a.size,
+      downloadUrl: /\.apk$/i.test(a.name)
+        ? '/download/' + encodeURIComponent(a.name)
+        : a.browser_download_url,
+      githubUrl: a.browser_download_url,
+      downloadCount: a.download_count,
+    })),
+  };
+}
+
+// ── 调用 GitHub API（https + 重定向 + UA + token）────────────────
+function githubGet(apiPath) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      path: apiPath,
+      method: 'GET',
+      headers: {
+        'User-Agent': 'Navi-Link-Server',
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    };
+    if (CONFIG.token) options.headers.Authorization = `Bearer ${CONFIG.token}`;
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(data);
+        } else {
+          const err = new Error(`GitHub API ${res.statusCode}: ${data.slice(0, 200)}`);
+          err.statusCode = res.statusCode;
+          reject(err);
+        }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(10000, () => req.destroy(new Error('GitHub API 请求超时')));
+    req.end();
+  });
+}
+
+// ── APK 下载代理 ───────────────────────────────────────────────
+// 进行中的回源下载：文件名 → Promise，避免并发重复下载同一文件
+const inflightDownloads = new Map();
+
+/**
+ * 处理 /download/<filename>：
+ *   1. 文件名安全校验（仅允许 release 资产名，禁止路径穿越）
+ *   2. 命中本地缓存 → 直接发送
+ *   3. 未命中 → 从 GitHub 回源下载并落盘，完成后发送
+ */
+async function handleDownload(pathname, req, res) {
+  const filename = path.basename(decodeURIComponent(pathname.slice('/download/'.length)));
+
+  // 安全：文件名不得为空、不得含分隔符、必须是合理的资产名
+  if (!filename || filename.includes('/') || filename.includes('\\') || filename === '..') {
+    return sendJson(res, 400, { error: 'bad_filename' });
+  }
+
+  // 找到该文件对应的 GitHub 回源地址：从缓存的 release 资产中查
+  const sourceUrl = await resolveAssetUrl(filename);
+  if (!sourceUrl) {
+    return sendJson(res, 404, { error: 'asset_not_found', message: '未在最新发布中找到该文件' });
+  }
+
+  const localPath = path.join(CONFIG.apkCacheDir, filename);
+
+  // 命中本地缓存
+  if (fs.existsSync(localPath)) {
+    return sendFile(res, localPath, filename, req.method === 'HEAD');
+  }
+
+  // HEAD 请求且无缓存：直接回 200（避免触发下载），交由客户端 GET 时再缓存
+  if (req.method === 'HEAD') {
+    res.writeHead(200, { 'Content-Type': 'application/vnd.android.package-archive' });
+    return res.end();
+  }
+
+  // 回源下载（并发去重）
+  try {
+    if (!inflightDownloads.has(filename)) {
+      inflightDownloads.set(filename, fetchToFile(sourceUrl, localPath).finally(() => {
+        inflightDownloads.delete(filename);
+      }));
+    }
+    await inflightDownloads.get(filename);
+  } catch (err) {
+    console.error('[DOWNLOAD] 回源失败:', err.message);
+    // 清理可能的半成品
+    try { fs.existsSync(localPath) && fs.unlinkSync(localPath); } catch {}
+    return sendJson(res, 502, { error: 'origin_fetch_failed', message: String(err.message || err) });
+  }
+
+  return sendFile(res, localPath, filename, false);
+}
+
+/** 根据资产文件名，从（必要时刷新的）release 数据里找到 GitHub 真实下载地址。 */
+async function resolveAssetUrl(filename) {
+  // 确保有 release 数据
+  if (!cache.data) {
+    try {
+      cache.data = await fetchLatestRelease();
+      cache.fetchedAt = Date.now();
+    } catch {
+      return null;
+    }
+  }
+  const assets = (cache.data && cache.data.assets) || [];
+  const hit = assets.find((a) => a.name === filename);
+  return hit ? hit.githubUrl : null;
+}
+
+/** 从 url 下载到 destPath（先写临时文件再原子重命名），自动跟随重定向。 */
+function fetchToFile(url, destPath, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    if (redirectsLeft < 0) return reject(new Error('重定向次数过多'));
+
+    const tmpPath = destPath + '.part';
+    const options = {
+      headers: { 'User-Agent': 'Navi-Link-Server', Accept: 'application/octet-stream' },
+    };
+    if (CONFIG.token && url.startsWith('https://api.github.com')) {
+      options.headers.Authorization = `Bearer ${CONFIG.token}`;
+    }
+
+    const req = https.get(url, options, (res) => {
+      // 跟随重定向（GitHub 资产会 302 到 objects.githubusercontent.com）
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        return resolve(fetchToFile(res.headers.location, destPath, redirectsLeft - 1));
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`回源 HTTP ${res.statusCode}`));
+      }
+      const out = fs.createWriteStream(tmpPath);
+      res.pipe(out);
+      out.on('finish', () => out.close(() => {
+        try {
+          fs.renameSync(tmpPath, destPath);
+          console.log('[DOWNLOAD] 已缓存:', path.basename(destPath));
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }));
+      out.on('error', (e) => {
+        try { fs.unlinkSync(tmpPath); } catch {}
+        reject(e);
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(120000, () => req.destroy(new Error('回源下载超时')));
+  });
+}
+
+/** 发送本地文件（APK），带正确的下载头。 */
+function sendFile(res, filePath, filename, headOnly) {
+  let stat;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    return sendJson(res, 404, { error: 'not_found' });
+  }
+  res.writeHead(200, {
+    'Content-Type': 'application/vnd.android.package-archive',
+    'Content-Length': stat.size,
+    'Content-Disposition': `attachment; filename="${filename}"`,
+    'Cache-Control': 'public, max-age=86400',
+  });
+  if (headOnly) return res.end();
+  fs.createReadStream(filePath).pipe(res);
+}
+
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.woff2': 'font/woff2',
+};
+
+function serveStatic(pathname, res) {
+  // 根路径 → index.html
+  let rel = pathname === '/' ? '/index.html' : pathname;
+  // 防目录穿越
+  const safePath = path.normalize(path.join(PUBLIC_DIR, rel));
+  if (!safePath.startsWith(PUBLIC_DIR)) {
+    return sendJson(res, 403, { error: 'forbidden' });
+  }
+
+  fs.stat(safePath, (err, stat) => {
+    if (err || !stat.isFile()) {
+      // SPA 回退：未知路径返回首页
+      const fallback = path.join(PUBLIC_DIR, 'index.html');
+      return fs.readFile(fallback, (e2, buf) => {
+        if (e2) return sendJson(res, 404, { error: 'not_found' });
+        res.writeHead(200, { 'Content-Type': MIME['.html'] });
+        res.end(buf);
+      });
+    }
+    const ext = path.extname(safePath).toLowerCase();
+    res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+    fs.createReadStream(safePath).pipe(res);
+  });
+}
+
+// ── 工具函数 ────────────────────────────────────────────────────
+function sendJson(res, code, obj) {
+  const buf = Buffer.from(JSON.stringify(obj, null, 2));
+  res.writeHead(code, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(buf);
+}
+
+/** 极简 .env 加载器（无外部依赖）。文件不存在则静默跳过。 */
+function loadDotEnv(file) {
+  try {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const line of text.split('\n')) {
+      const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+      if (!m) continue;
+      const key = m[1];
+      let val = m[2].trim();
+      if (val.startsWith('#')) continue;
+      // 去引号
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1);
+      }
+      if (process.env[key] === undefined) process.env[key] = val;
+    }
+  } catch {
+    /* .env 不存在，忽略 */
+  }
+}


### PR DESCRIPTION
## 概述

为 Navi-Link 增加一套完整的**应用内自动更新系统**，并配套**官网**与**自动化发布流水线**。整套设计的核心约束是：**客户端不直连 GitHub**（国内访问 GitHub API/Release 资源不稳定），而是通过一个**自有轻量服务**中转——由服务端缓存 GitHub Release 信息、并代理 APK 下载，客户端只与该服务通信。

本 PR 已 rebase 到最新 `dev`（2.5.5 / versionCode 255），**未改动版本号、签名密钥（`navi.jks`）或任何既有功能**，全部为增量。本地 `:app:assembleDebug` 构建通过。

---

## 改了什么

### 1. App 端（应用内更新）
- **检查更新入口**：放在「系统与外观」选项卡内（`activity_main.xml` 的 `card_check_update` 卡片），展示当前版本号，点击手动检查；首次启动静默检查，仅在有新版本时弹窗。
- **更新弹窗** `UpdateDialog.java`：展示版本号、更新日志，「立即更新」走应用内下载。
- **下载** `ApkDownloader.java`：带进度回调、手动跟随重定向、`.part` 临时文件原子改名。
- **三级安装链** `ApkInstaller.java`：优先 `PackageInstaller` 会话安装（系统确认弹窗，非 root 静默），失败回退 `InstallerX`（`com.rosan.installer.x`），再回退系统安装器。`InstallResultReceiver.java` 处理 `STATUS_PENDING_USER_ACTION` 等结果。
- **版本比较** `UpdateChecker.java`：语义化版本比较，请求服务端 `/api/latest`。
- 服务地址由编译期常量 `BuildConfig.UPDATE_BASE_URL` 注入，**不在任何界面显示**，可被 Gradle 属性 / 环境变量覆盖。

### 2. 服务端 `server/`（零依赖 Node.js，仅用内置模块）
- `GET /api/latest`：返回缓存的最新 Release（版本、更新日志、APK 元信息）。
- `POST /api/sync`：强制从 GitHub 刷新缓存（官网「手动同步」按钮用）。
- `GET /download/<filename>`：APK 下载代理——本地有缓存直接返回，否则从 GitHub 拉取落盘后返回（带并发去重、原子落盘）。客户端拿到的下载地址是该服务的相对路径，**不暴露 GitHub 直链**。
- `public/`：**官网首页**，苹果液态玻璃（Liquid Glass）风格，展示最新版本、下载入口、更新日志、手动同步。
- 附 `navi-link.service`（systemd）、`.env.example`、`README.md`，方便部署。

### 3. 自动化发布 `.github/workflows/release.yml`
- 推送 `v*` tag 时触发：构建**已签名** Release APK → 创建 GitHub Release 并上传 APK。
- 服务端会缓存这个 Release，App 即可检测到更新，形成闭环。

---

## 需要你（作者）测试什么

> 下面几项依赖你本地环境 / 服务器，我无法在我侧完整验证，**烦请合并前确认**：

1. **签名构建**（最关键）：我本地**没有 keystore 密码**，只跑通了 `assembleDebug`。请用你的 `navi.jks` 密码跑一次：
   ```
   ./gradlew :app:assembleRelease \
     -PNAVI_STORE_PASSWORD=*** -PNAVI_KEY_ALIAS=*** -PNAVI_KEY_PASSWORD=***
   ```
   确认 release APK 能正常签名、安装、覆盖升级（**升级安装要求新旧 APK 同一签名**，这点务必验证）。
2. **真机更新链路**：装一个低版本，部署服务端后点「检查更新」，验证：弹窗 → 下载进度 → 安装。重点测**三级安装链回退**：未装 InstallerX 时是否正确落到系统安装器；首次安装时「允许安装未知来源」引导是否正常。
3. **服务端**：`cd server && node server.js`（Node 18+），配好 `.env`（仓库地址、端口）。验证 `/api/latest`、`/api/sync`、`/download/<apk>` 三个接口，以及官网首页渲染。
4. **GitHub Action**：打一个测试 tag，确认 workflow 能签名并发布 Release（需先配置下方 Secrets）。

---

## 需要你配置什么

### A. GitHub 仓库 Secrets（CI 签名发布必需）
在 `Settings → Secrets and variables → Actions` 添加：

| Secret | 含义 |
|---|---|
| `SIGNING_KEYSTORE_BASE64` | `navi.jks` 的 base64（`base64 -w0 navi.jks`） |
| `SIGNING_STORE_PASSWORD` | keystore 密码 |
| `SIGNING_KEY_ALIAS` | key alias |
| `SIGNING_KEY_PASSWORD` | key 密码 |

> 说明：仓库里现有的 `navi.jks` 是你初版就提交的，本 PR 未改动它。CI 走 Secret 注入，不依赖仓库内的 keystore。是否要把 keystore 移出仓库由你决定，本 PR 不涉及。

### B. 更新服务地址
`app/build.gradle` 里 `UPDATE_BASE_URL` 默认值目前指向我的测试服务，请改成你自己的服务域名（或构建时用 `-PNAVI_UPDATE_BASE_URL=...` / 环境变量覆盖）。这是编译期常量，不在 App 界面显示。

### C. 服务端部署
参考 `server/README.md`：配 `.env`（GitHub 仓库、token 可选、端口、缓存目录），用 `navi-link.service` 注册 systemd 常驻。

---

## 重点审查代码

- `app/src/main/java/com/navi/link/ApkInstaller.java` — 三级安装链与 FileProvider 授权，安装相关权限敏感，建议重点看。
- `app/src/main/java/com/navi/link/UpdateChecker.java` — 版本比较与服务端 JSON 解析逻辑。
- `app/src/main/AndroidManifest.xml` — 新增 `REQUEST_INSTALL_PACKAGES`、`INTERNET` 等权限及 FileProvider 声明。
- `server/server.js` — 下载代理与缓存逻辑（原子落盘、并发去重、重定向跟随）。
- `app/build.gradle` — 签名配置为惰性：仅当密钥齐全时启用，缺失时不影响本地 debug 构建。

---

## 兼容性 / 安全说明
- 全部为新增功能，未触碰既有悬浮窗、导航、巡航等逻辑。
- 客户端不出现任何硬编码外链，服务地址为可覆盖的编译期常量。
- 服务端零第三方依赖，仅用 Node 内置模块，便于在树莓派等设备常驻。
- `.gitignore` 已覆盖 `.env`、`node_modules/`、APK 缓存目录，不会提交运行时残留。
